### PR TITLE
Add .dockerignore for node_modules 

### DIFF
--- a/API/.dockerignore
+++ b/API/.dockerignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
This PR adds a .dockerignore file to exclude the node_modules directory during Docker image builds. This helps prevent host-compiled binaries from being copied into the container, ensuring native modules like bcrypt are built for the correct platform (Linux).

 See: Issue #44 