### PR TITLE
Depa/command

### DIFF
--- a/API/src/classes/commands/AddFavouriteCommand.js
+++ b/API/src/classes/commands/AddFavouriteCommand.js
@@ -1,0 +1,21 @@
+import Command from "./Command.js";
+
+class AddFavouriteCommand extends Command {
+	constructor(favouriteService, userId, accommodationId) {
+		super();
+		this.favouriteService = favouriteService;
+		this.userId = userId;
+		this.accommodationId = accommodationId;
+	}
+
+	async execute() {
+		return await this.favouriteService.add(this.userId, this.accommodationId);
+	}
+
+	async undo() {
+		// Hoàn tác bằng cách xóa cơ sở lưu trú khỏi danh sách yêu thích
+		return await this.favouriteService.remove(this.userId, this.accommodationId);
+	}
+}
+
+export default AddFavouriteCommand;

--- a/API/src/classes/commands/AddFavouriteCommand.js
+++ b/API/src/classes/commands/AddFavouriteCommand.js
@@ -9,12 +9,15 @@ class AddFavouriteCommand extends Command {
 	}
 
 	async execute() {
-		return await this.favouriteService.add(this.userId, this.accommodationId);
+		await this.favouriteService.add(this.userId, this.accommodationId);
+		const updatedList = await this.favouriteService.findByUserId(this.userId);
+		return { favouriteList: updatedList.accommodations };
 	}
 
 	async undo() {
-		// Hoàn tác bằng cách xóa cơ sở lưu trú khỏi danh sách yêu thích
-		return await this.favouriteService.remove(this.userId, this.accommodationId);
+		await this.favouriteService.remove(this.userId, this.accommodationId);
+		const updatedList = await this.favouriteService.findByUserId(this.userId);
+		return { favouriteList: updatedList.accommodations };
 	}
 }
 

--- a/API/src/classes/commands/Command.js
+++ b/API/src/classes/commands/Command.js
@@ -1,0 +1,11 @@
+class Command {
+	execute() {
+		throw new Error("Execute method not implemented");
+	}
+
+	undo() {
+		throw new Error("Undo method not implemented");
+	}
+}
+
+export default Command;

--- a/API/src/classes/commands/RemoveFavouriteCommand.js
+++ b/API/src/classes/commands/RemoveFavouriteCommand.js
@@ -9,12 +9,15 @@ class RemoveFavouriteCommand extends Command {
 	}
 
 	async execute() {
-		return await this.favouriteService.remove(this.userId, this.accommodationId);
+		await this.favouriteService.remove(this.userId, this.accommodationId);
+		const updatedList = await this.favouriteService.findByUserId(this.userId);
+		return { favouriteList: updatedList.accommodations };
 	}
 
 	async undo() {
-		// Hoàn tác bằng cách thêm lại cơ sở lưu trú vào danh sách yêu thích
-		return await this.favouriteService.add(this.userId, this.accommodationId);
+		await this.favouriteService.add(this.userId, this.accommodationId);
+		const updatedList = await this.favouriteService.findByUserId(this.userId);
+		return { favouriteList: updatedList.accommodations };
 	}
 }
 

--- a/API/src/classes/commands/RemoveFavouriteCommand.js
+++ b/API/src/classes/commands/RemoveFavouriteCommand.js
@@ -1,0 +1,21 @@
+import Command from "./Command.js";
+
+class RemoveFavouriteCommand extends Command {
+	constructor(favouriteService, userId, accommodationId) {
+		super();
+		this.favouriteService = favouriteService;
+		this.userId = userId;
+		this.accommodationId = accommodationId;
+	}
+
+	async execute() {
+		return await this.favouriteService.remove(this.userId, this.accommodationId);
+	}
+
+	async undo() {
+		// Hoàn tác bằng cách thêm lại cơ sở lưu trú vào danh sách yêu thích
+		return await this.favouriteService.add(this.userId, this.accommodationId);
+	}
+}
+
+export default RemoveFavouriteCommand;

--- a/API/src/controllers/favourite.controller.js
+++ b/API/src/controllers/favourite.controller.js
@@ -1,6 +1,9 @@
 import FavouriteService from "../services/favourite.service.js";
+import AddFavouriteCommand from "../classes/commands/AddFavouriteCommand.js";
+import RemoveFavouriteCommand from "../classes/commands/RemoveFavouriteCommand.js";
 
-export default {	async getFavouriteList(req, res) {
+export default {
+	async getFavouriteList(req, res) {
 		try {
 			const userId = req.user?.id;
 			if (!userId) return res.status(401).json({ success: false, error: { code: 401, message: "Unauthorized" } });
@@ -50,8 +53,9 @@ export default {	async getFavouriteList(req, res) {
 				});
 			}
 
-			// Call the service to add the accommodation to the user's favourites
-			const result = await FavouriteService.add(userId, accommodationId);
+			// Create and execute command
+			const command = new AddFavouriteCommand(FavouriteService, userId, accommodationId);
+			const result = await command.execute();
 
 			if (result) {
 				return res.status(200).json({
@@ -97,9 +101,9 @@ export default {	async getFavouriteList(req, res) {
 				});
 			}
 
-			// Call the service to remove the accommodation from the user's favourites
-			// The service will check if the accommodation is in the list and remove it if it is
-			const result = await FavouriteService.remove(userId, accommodationId);
+			// Create and execute command
+			const command = new RemoveFavouriteCommand(FavouriteService, userId, accommodationId);
+			const result = await command.execute();
 
 			if (result) {
 				return res.status(200).json({

--- a/API/src/controllers/favourite.controller.js
+++ b/API/src/controllers/favourite.controller.js
@@ -62,9 +62,11 @@ export default {
 			const result = await command.execute();
 
 			// Save command to Redis history
-			const commandData = { type: "AddFavouriteCommand", userId, accommodationId };
-			await redis.lpush(`command:history:${userId}`, JSON.stringify(commandData));
-			await redis.ltrim(`command:history:${userId}`, 0, HISTORY_LIMIT - 1);
+            const commandData = { type: "AddFavouriteCommand", userId, accommodationId };
+			const multi = redis.multi();
+			multi.lpush(`command:history:${userId}`, JSON.stringify(commandData));
+			multi.ltrim(`command:history:${userId}`, 0, HISTORY_LIMIT - 1);
+			await multi.exec();
 
 			if (result) {
 				return res.status(200).json({
@@ -116,9 +118,11 @@ export default {
 			const result = await command.execute();
 
 			// Save command to Redis history
-			const commandData = { type: "RemoveFavouriteCommand", userId, accommodationId };
-			await redis.lpush(`command:history:${userId}`, JSON.stringify(commandData));
-			await redis.ltrim(`command:history:${userId}`, 0, HISTORY_LIMIT - 1);
+            const commandData = { type: "RemoveFavouriteCommand", userId, accommodationId };
+			const multi = redis.multi();
+			multi.lpush(`command:history:${userId}`, JSON.stringify(commandData));
+			multi.ltrim(`command:history:${userId}`, 0, HISTORY_LIMIT - 1);
+			await multi.exec();
 
 			if (result) {
 				return res.status(200).json({

--- a/API/src/controllers/favourite.controller.js
+++ b/API/src/controllers/favourite.controller.js
@@ -1,6 +1,10 @@
 import FavouriteService from "../services/favourite.service.js";
 import AddFavouriteCommand from "../classes/commands/AddFavouriteCommand.js";
 import RemoveFavouriteCommand from "../classes/commands/RemoveFavouriteCommand.js";
+import RedisClient from "../clients/RedisClient.js";
+
+const redis = RedisClient.getClient();
+const HISTORY_LIMIT = 10; // Maximum number of commands to keep in history
 
 export default {
 	async getFavouriteList(req, res) {
@@ -57,10 +61,16 @@ export default {
 			const command = new AddFavouriteCommand(FavouriteService, userId, accommodationId);
 			const result = await command.execute();
 
+			// Save command to Redis history
+			const commandData = { type: "AddFavouriteCommand", userId, accommodationId };
+			await redis.lpush(`command:history:${userId}`, JSON.stringify(commandData));
+			await redis.ltrim(`command:history:${userId}`, 0, HISTORY_LIMIT - 1);
+
 			if (result) {
 				return res.status(200).json({
 					success: true,
 					message: "Successfully added to favourites",
+					payload: { accommodations: result.favouriteList },
 				});
 			} else {
 				return res.status(400).json({
@@ -105,10 +115,16 @@ export default {
 			const command = new RemoveFavouriteCommand(FavouriteService, userId, accommodationId);
 			const result = await command.execute();
 
+			// Save command to Redis history
+			const commandData = { type: "RemoveFavouriteCommand", userId, accommodationId };
+			await redis.lpush(`command:history:${userId}`, JSON.stringify(commandData));
+			await redis.ltrim(`command:history:${userId}`, 0, HISTORY_LIMIT - 1);
+
 			if (result) {
 				return res.status(200).json({
 					success: true,
 					message: "Successfully removed from favourites",
+					payload: { accommodations: result.favouriteList },
 				});
 			} else {
 				return res.status(400).json({
@@ -127,6 +143,84 @@ export default {
 					code: 500,
 					message: "Internal Server Error",
 				},
+			});
+		}
+	},
+	async undo(req, res) {
+		try {
+			const userId = req.user?.id;
+			if (!userId) return res.status(401).json({ success: false, error: { code: 401, message: "Unauthorized" } });
+
+			// Kiểm tra kết nối Redis
+			if (redis.status !== "ready") {
+				return res.status(503).json({
+					success: false,
+					error: { code: 503, message: "Redis service unavailable" },
+				});
+			}
+
+			// Lấy lệnh cuối từ lịch sử
+			const commandData = await redis.rpop(`command:history:${userId}`);
+			if (!commandData) {
+				return res.status(400).json({
+					success: false,
+					error: { code: 400, message: "No commands to undo" },
+				});
+			}
+
+			// Phân tích lệnh
+			let commandInfo;
+			try {
+				commandInfo = JSON.parse(commandData);
+			} catch (parseError) {
+				console.error("Error parsing command data:", parseError);
+				return res.status(500).json({
+					success: false,
+					error: { code: 500, message: "Invalid command data" },
+				});
+			}
+
+			const { type, userId: cmdUserId, accommodationId } = commandInfo;
+			if (!type || !cmdUserId || !accommodationId) {
+				return res.status(400).json({
+					success: false,
+					error: { code: 400, message: "Incomplete command data" },
+				});
+			}
+
+			// Ghi log để debug
+			console.log("Undoing command:", { type, userId: cmdUserId, accommodationId });
+
+			// Tạo lệnh hoàn tác
+			let command;
+			if (type === "AddFavouriteCommand") {
+				command = new RemoveFavouriteCommand(FavouriteService, cmdUserId, accommodationId);
+			} else if (type === "RemoveFavouriteCommand") {
+				command = new AddFavouriteCommand(FavouriteService, cmdUserId, accommodationId);
+			} else {
+				return res.status(400).json({
+					success: false,
+					error: { code: 400, message: "Invalid command type" },
+				});
+			}
+
+			// Thực thi hoàn tác
+			const result = await command.execute();
+
+			// Cập nhật cache Redis
+			await redis.set(`favourite:user:${userId}`, JSON.stringify(result.favouriteList), "EX", 3600);
+
+			return res.status(200).json({
+				success: true,
+				message: `Successfully undid ${type}`,
+				payload: { accommodations: result.favouriteList },
+			});
+		} catch (error) {
+			console.error("Error undoing favourite command:", error);
+			const statusCode = error.message.includes("already in") ? 409 : error.message.includes("not in") ? 404 : 500;
+			return res.status(statusCode).json({
+				success: false,
+				error: { code: statusCode, message: error.message || "Internal Server Error" },
 			});
 		}
 	},

--- a/API/src/routes/favourite.routes.js
+++ b/API/src/routes/favourite.routes.js
@@ -7,5 +7,6 @@ favouriteRouter.get("/", favouriteController.getFavouriteList);
 // Add or remove a favourite accommodation for favourite list of a user
 favouriteRouter.post("/add", favouriteController.addToFavourite);
 favouriteRouter.delete("/remove/:accommodationId", favouriteController.removeFromFavourite);
+favouriteRouter.post("/undo", favouriteController.undo);
 
 export default favouriteRouter;

--- a/API/src/services/favourite.service.js
+++ b/API/src/services/favourite.service.js
@@ -29,8 +29,16 @@ export default {
 	// Add an accommodation to the user's favourite list
 	async add(userId, accommodationId) {
 		try {
-			// Find the user's favourite list
+			// Validate input parameters
+			if (!userId || !accommodationId) {
+				throw new Error("userId and accommodationId are required.");
+			}
+
+			// Check if the user has a favourite list
 			const favouriteListModel = await FavouriteRepository.findByUser(userId);
+			if (!favouriteListModel) {
+				throw new Error(`Favourite list for user ${userId} not found.`);
+			}
 
 			// Check if the accommodation exists
 			const accommodationModel = await AccommodationRepository.findById(accommodationId);
@@ -38,8 +46,8 @@ export default {
 				throw new Error(`Accommodation ${accommodationId} not found.`);
 			}
 
+			// Create instances of FavouriteList and Accommodation
 			const accommInstance = Accommodation.fromModel(accommodationModel);
-
 			const listInstance = FavouriteList.fromModel(favouriteListModel);
 
 			// Check if the accommodation is already in the user's favourite list
@@ -50,7 +58,6 @@ export default {
 
 			// Add the accommodation to the user's favourite list
 			listInstance.addAccommodation(accommInstance);
-
 			await FavouriteRepository.save(listInstance);
 
 			return true;
@@ -63,12 +70,25 @@ export default {
 	// Remove an accommodation from the user's favourite list
 	async remove(userId, accommodationId) {
 		try {
+			// Validate input parameters
+			if (!userId || !accommodationId) {
+				throw new Error("userId and accommodationId are required.");
+			}
+
+			// Check if the user has a favourite list
 			const favouriteListModel = await FavouriteRepository.findByUser(userId);
+			if (!favouriteListModel) {
+				throw new Error(`Favourite list for user ${userId} not found.`);
+			}
 
+			// Check if the accommodation exists
 			const accommodationModel = await AccommodationRepository.findById(accommodationId);
+			if (!accommodationModel) {
+				throw new Error(`Accommodation ${accommodationId} not found.`);
+			}
 
+			// Create instances of FavouriteList and Accommodation
 			const listInstance = FavouriteList.fromModel(favouriteListModel);
-
 			const accommInstance = Accommodation.fromModel(accommodationModel);
 
 			// Check if accommodation has been added to favorite list
@@ -77,13 +97,14 @@ export default {
 				throw new Error(`Accommodation ${accommodationId} is not in FavouriteList of user ${userId}.`);
 			}
 
+			// Remove the accommodation from the user's favourite list
 			listInstance.removeAccommodation(accommInstance);
-
 			await FavouriteRepository.save(listInstance);
+
 			return true;
 		} catch (error) {
 			console.error("Error in FavouriteService.remove:", error);
-			return false;
+			throw new Error(error.message);
 		}
 	},
 };

--- a/UI/src/features/favourite/favoritesSlice.js
+++ b/UI/src/features/favourite/favoritesSlice.js
@@ -1,5 +1,5 @@
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
-import { addFavouriteApi, getFavouriteApi, removeFavouriteApi } from "./favouriteApi";
+import { addFavouriteApi, getFavouriteApi, removeFavouriteApi, undoFavouriteApi } from "./favouriteApi";
 import { logoutUser } from "../auth/authSlice";
 
 export const getFavourite = createAsyncThunk("/favourites", async (_, { rejectWithValue }) => {
@@ -40,6 +40,15 @@ export const removeFavourite = createAsyncThunk("/favourites/remove", async (acc
 	}
 });
 
+export const undoFavourite = createAsyncThunk("/favourites/undo", async (_, { rejectWithValue }) => {
+	try {
+		const accomms = await undoFavouriteApi();
+		return accomms;
+	} catch (error) {
+		return rejectWithValue(error.response?.data?.error?.message || `Failed to undo favourite action: ${error.message}`);
+	}
+});
+
 const initialState = {
 	accomms: [], // lưu danh sách các object accommodation được đánh dấu yêu thích
 	loading: false,
@@ -56,6 +65,7 @@ const favoritesSlice = createSlice({
 	},
 	extraReducers: (builder) => {
 		builder
+			// Get Favourite
 			.addCase(getFavourite.fulfilled, (state, action) => {
 				state.accomms = action.payload;
 				state.loading = false;
@@ -70,6 +80,7 @@ const favoritesSlice = createSlice({
 				state.error = action.payload;
 				console.error("Error load favourites:", action.payload);
 			})
+			// Add Favourite
 			.addCase(addFavourite.fulfilled, (state, action) => {
 				const exists = state.accomms.some((a) => a.id === action.payload.id);
 				if (!exists) state.accomms.push(action.payload);
@@ -84,6 +95,7 @@ const favoritesSlice = createSlice({
 				state.error = action.payload;
 				console.error("Error add favourites:", action.payload);
 			})
+			// Remove Favourite
 			.addCase(removeFavourite.fulfilled, (state, action) => {
 				state.accomms = state.accomms.filter((a) => a.id !== action.payload);
 				state.loading = false;
@@ -98,6 +110,22 @@ const favoritesSlice = createSlice({
 				state.error = action.payload;
 				console.error("Error remove favourites:", action.payload);
 			})
+			// Undo Favourite
+			.addCase(undoFavourite.pending, (state) => {
+				state.loading = true;
+				state.error = "";
+			})
+			.addCase(undoFavourite.fulfilled, (state, action) => {
+				state.accomms = action.payload;
+				state.loading = false;
+				state.error = "";
+			})
+			.addCase(undoFavourite.rejected, (state, action) => {
+				state.loading = false;
+				state.error = action.payload;
+				console.error("Error undoing favourite:", action.payload);
+			})
+			// Logout
 			.addCase(logoutUser.fulfilled, (state) => {
 				state.accomms = [];
 				state.loading = false;

--- a/UI/src/features/favourite/favouriteApi.js
+++ b/UI/src/features/favourite/favouriteApi.js
@@ -43,3 +43,17 @@ export const removeFavouriteApi = async (accommId) => {
 		throw error;
 	}
 };
+
+// Returns accommodations list if success
+export const undoFavouriteApi = async () => {
+    try {
+        const response = await axiosInstance.post("/favourite/undo");
+        if (response.data && response.data.success) {
+            return response.data.payload.accommodations;
+        }
+        throw new Error(response.data?.error?.message || "Failed to undo favourite action");
+    } catch (error) {
+        console.error("Error in undoFavouriteApi:", error);
+        throw error;
+    }
+};

--- a/UI/src/pages/Favorites/FavoritesPage.jsx
+++ b/UI/src/pages/Favorites/FavoritesPage.jsx
@@ -15,62 +15,71 @@ const FavoritesPage = () => {
 
 	const [snackbar, setSnackbar] = useState({ open: false, message: "", severity: "success" });
 	const [initialLoad, setInitialLoad] = useState(true);
-	const [canUndo, setCanUndo] = useState(false); // Quản lý trạng thái undo
-	const [isUndoing, setIsUndoing] = useState(false); // Ngăn nhấn Ctrl + Z nhiều lần
+	const [canUndo, setCanUndo] = useState(false); // Track undo availability
+	const [isUndoing, setIsUndoing] = useState(false); // Prevent multiple Ctrl + Z
+	const [undoTimeout, setUndoTimeout] = useState(null); // Track undo timeout
 
 	// Get auth state from Redux
 	const { isLoggedIn, loading: authLoading, user } = useSelector((state) => state.auth);
 
+	// Fetch favourites when logged in
 	useEffect(() => {
 		if (!isLoggedIn || !user) {
-			// Don't fetch if not logged in
 			return;
 		}
 		dispatch(getFavourite());
 	}, [isLoggedIn, user, dispatch]);
 
+	// Disable initial load after first render
 	useEffect(() => {
-		// This effect runs once after the first render to set initial load to false
 		const timer = setTimeout(() => setInitialLoad(false), 500);
 		return () => clearTimeout(timer);
 	}, []);
 
-	// Handle Ctrl + Z to Undo
+	// Handle Ctrl + Z for undo with debounce
 	useEffect(() => {
+		let debounceTimer;
 		const handleKeyDown = (event) => {
 			if (event.ctrlKey && event.key === "z" && canUndo && !isUndoing) {
 				event.preventDefault();
-				setIsUndoing(true);
-				console.log(
-					"Attempting undo, current favourites:",
-					favorites.map((item) => item.id)
-				);
-				dispatch(undoFavourite())
-					.unwrap()
-					.then(() => {
-						setSnackbar({
-							open: true,
-							message: "Favorite accommodation restored",
-							severity: "success",
+				clearTimeout(debounceTimer);
+				debounceTimer = setTimeout(() => {
+					setIsUndoing(true);
+					console.log(
+						"Attempting undo, current favourites:",
+						favorites.map((item) => item.id)
+					);
+					dispatch(undoFavourite())
+						.unwrap()
+						.then(() => {
+							setSnackbar({
+								open: true,
+								message: "Đã khôi phục cơ sở lưu trú yêu thích",
+								severity: "success",
+							});
+						})
+						.catch((error) => {
+							setSnackbar({
+								open: true,
+								message: error || "Không thể hoàn tác hành động",
+								severity: "error",
+							});
+						})
+						.finally(() => {
+							setIsUndoing(false);
+							setCanUndo(false); // Disable undo after attempt
+							clearTimeout(undoTimeout);
 						});
-					})
-					.catch((error) => {
-						setSnackbar({
-							open: true,
-							message: error || "Action cannot be undone",
-							severity: "error",
-						});
-					})
-					.finally(() => {
-						setIsUndoing(false);
-						setCanUndo(false); // Tắt undo sau khi thực hiện
-					});
+				}, 100); // Debounce 100ms
 			}
 		};
 
 		window.addEventListener("keydown", handleKeyDown);
-		return () => window.removeEventListener("keydown", handleKeyDown);
-	}, [dispatch, canUndo, isUndoing, favorites]);
+		return () => {
+			window.removeEventListener("keydown", handleKeyDown);
+			clearTimeout(debounceTimer);
+		};
+	}, [dispatch, canUndo, isUndoing, favorites, undoTimeout]);
 
 	// Close snackbar
 	const handleCloseSnackbar = () => {
@@ -84,29 +93,30 @@ const FavoritesPage = () => {
 			setCanUndo(true);
 			setSnackbar({
 				open: true,
-				message: "Accommodation removed from favorites",
+				message: "Đã xóa cơ sở lưu trú khỏi yêu thích",
 				severity: "success",
 			});
-			// Tắt undo sau 10 giây
-			setTimeout(() => setCanUndo(false), 10000);
+			// Disable undo after 10 seconds
+			const timeout = setTimeout(() => setCanUndo(false), 10000);
+			setUndoTimeout(timeout);
 		} catch (error) {
 			setSnackbar({
 				open: true,
-				message: error || "Error removing accommodation from favorites. Please try again.",
+				message: error || "Không thể xóa cơ sở lưu trú",
 				severity: "error",
 			});
 		}
 	};
 
-	// Show a loading state if either authentication is loading or favorites are loading
+	// Show loading state if authenticating or fetching favourites
 	const isPageLoading = authLoading || loading;
 
-	// Check if we have an auth token in localStorage
+	// Check for auth token in localStorage
 	const hasAuthToken = () => {
 		return !!localStorage.getItem("token");
 	};
 
-	// During initial load or when auth is still loading, show loading spinner instead of redirecting
+	// Show loading spinner during initial load or auth
 	if (initialLoad || authLoading) {
 		return (
 			<>
@@ -120,8 +130,7 @@ const FavoritesPage = () => {
 		);
 	}
 
-	// Only redirect to login if the auth loading has completed AND user is not logged in
-	// AND there's no token in storage (to handle page reloads before redux is ready)
+	// Redirect to login if not logged in and no token
 	if (!isLoggedIn && !hasAuthToken()) {
 		return <Navigate to="/login" state={{ from: "/favorites" }} replace />;
 	}
@@ -132,10 +141,10 @@ const FavoritesPage = () => {
 			<Container maxWidth="lg" sx={{ py: 4, mt: 8 }}>
 				<Box mb={4}>
 					<Typography variant="h4" component="h1" gutterBottom fontWeight="bold">
-						Your Saved Accommodations
+						Cơ sở lưu trú đã lưu
 					</Typography>
 					<Typography variant="body1" color="text.secondary">
-						View and manage your favorite accommodations
+						Xem và quản lý các cơ sở lưu trú yêu thích của bạn
 					</Typography>
 					<Divider sx={{ mt: 2 }} />
 				</Box>
@@ -151,10 +160,10 @@ const FavoritesPage = () => {
 				) : favorites.length === 0 ? (
 					<Box textAlign="center" py={8}>
 						<Typography variant="h6" gutterBottom>
-							You don't have any saved accommodations yet
+							Bạn chưa lưu cơ sở lưu trú nào
 						</Typography>
 						<Typography variant="body1" color="text.secondary">
-							When you find places you like, save them here for easy access
+							Khi tìm thấy nơi bạn thích, lưu chúng tại đây để dễ truy cập
 						</Typography>
 					</Box>
 				) : (

--- a/UI/src/pages/Favorites/FavoritesPage.jsx
+++ b/UI/src/pages/Favorites/FavoritesPage.jsx
@@ -78,7 +78,7 @@ const FavoritesPage = () => {
 	};
 
 	// Handle removing an accommodation from favorites
-	const handleRemove = async () => {
+	const handleRemove = async (accommodation) => {
 		try {
 			await dispatch(removeFavourite(accommodation)).unwrap();
 			setCanUndo(true);


### PR DESCRIPTION
**Implement Command Pattern for Favourite Toggle with Undo Support**

## Description
This PR implements the Command Pattern for the favourite toggle functionality (add/remove accommodations from favourites) and adds an undo feature triggered by Ctrl + Z on the FavoritesPage. It leverages the existing RedisClient (Singleton Pattern) to store command history for undo operations. The changes enhance the user experience by allowing users to restore accidentally removed favourites within 10 seconds and improve code maintainability with a structured command-based approach.

## Why
- **Feature**: Users requested an undo feature for favourite removals to recover from accidental actions.
- **Enhancement**: Applying the Command Pattern makes the favourite toggle logic more modular, maintainable, and extensible.
- **Bug Fix**: Fixed `handleRemove` in FavoritesPage.jsx, which previously did not dispatch `removeFavourite`, causing removal failures.
- **Technical Debt**: Centralizes favourite operations with clear execute/undo logic, reducing future maintenance costs.

## Changes
### New Files
1. `API/src/classes/commands/Command.js`
   - Created abstract base class for Command Pattern with `execute` and `undo` methods.
2. `API/src/classes/commands/AddFavouriteCommand.js`
   - Implemented `AddFavouriteCommand` to add an accommodation to favourites and support undo by removing it.
   - Returns updated favourite list (`{ favouriteList: [...] }`) for consistency.
3. `API/src/classes/commands/RemoveFavouriteCommand.js`
   - Implemented `RemoveFavouriteCommand` to remove an accommodation and support undo by adding it back.
   - Returns updated favourite list (`{ favouriteList: [...] }`).

### Modified Files
1. `API/src/controllers/favourite.controller.js`
   - Integrated Command Pattern for `addToFavourite` and `removeFromFavourite` using `AddFavouriteCommand` and `RemoveFavouriteCommand`.
   - Added `undoFavourite` endpoint to handle `POST /favourite/undo`, popping the last command from Redis and executing its inverse.
   - Stored command history in Redis (`command:history:userId`) with a limit of 10 commands.
2. `API/src/routes/favourite.routes.js`
   - Added route for `POST /favourite/undo` to support undo functionality.
3. `API/src/services/favourite.service.js`
   - Updated to ensure compatibility with Command Pattern, maintaining existing add/remove logic.
   - Ensured `findByUserId` returns `{ accommodations: [...] }` for updated favourite lists.
4. `UI/src/features/favourite/favouriteApi.js`
   - Added `undoFavouriteApi` to call `POST /favourite/undo` and return the updated accommodations list.
5. `UI/src/features/favourite/favoritesSlice.js`
   - Added `undoFavourite` async thunk to handle undo actions.
   - Updated `extraReducers` to manage state for undo operations, syncing `state.favourites.accomms` with backend data.
6. `UI/src/pages/Favorites/FavoritesPage.jsx`
   - Fixed `handleRemove` to dispatch `removeFavourite` correctly, enabling favourite removal.
   - Added Ctrl + Z handling to trigger `undoFavourite` within a 10-second window.
   - Used `MuiAlert` in `Snackbar` for success/error notifications in Vietnamese (e.g., "Đã xóa cơ sở lưu trú khỏi yêu thích").
   - Eliminated page reload on favourite removal by relying on Redux state updates.

## Impact
- **Backend**: New endpoint `/favourite/undo` and command history stored in Redis. No database schema changes.
- **Frontend**: Affects FavoritesPage UI, Redux state (`favourites.accomms`), and user interactions (favourite toggle, Ctrl + Z).
- **Performance**: Minimal impact; Redis operations are lightweight, and command history is capped at 10.
- **Dependencies**: Requires Redis running (via existing RedisClient Singleton).

## Testing Instructions
1. **Setup**:
   - Ensure backend is running with Redis connected.
   - Log in to the frontend application.
2. **Test Favourite Toggle**:
   - Navigate to an accommodation detail page.
   - Click the heart button to add to favourites, verify it appears in FavoritesPage.
   - Click again to remove, verify it disappears from FavoritesPage.
3. **Test Undo Feature**:
   - Go to FavoritesPage.
   - Remove an accommodation using the heart button.
   - Verify card disappears and Snackbar shows "Đã xóa cơ sở lưu trú khỏi yêu thích".
   - Press Ctrl + Z within 10 seconds.
   - Verify card reappears and Snackbar shows "Đã khôi phục cơ sở lưu trú yêu thích".
   - Try Ctrl + Z after 10 seconds to confirm undo is disabled.
4. **Test Edge Cases**:
   - Remove an accommodation and try Ctrl + Z multiple times (should only work once).
   - Try Ctrl + Z without removing anything (should show error Snackbar: "Không thể hoàn tác hành động").
   - Verify Redis command history (`LRANGE command:history:userId 0 -1`) contains commands after removal.

## Related
- **Backend Dependencies**: Ensure `/favourite/undo` endpoint is deployed (this PR includes it).
- **Notes**:
  - Tested with RedisClient Singleton; confirm Redis is running in the environment.
  - Frontend uses Vietnamese for user-facing messages (Snackbar, UI text).
  - Command Pattern allows future extensions (e.g., redo functionality).